### PR TITLE
Asset pipeline and hashing content images

### DIFF
--- a/asset-pipeline.js
+++ b/asset-pipeline.js
@@ -1,0 +1,26 @@
+/**
+ * This is an example of an asset pipeline file.
+ *
+ * This file should have a method as default export, which will receive
+ * the asset content and should return either the modified content, or
+ * false, if original content should be kept.
+ *
+ * - content: content string
+ * - assetType: 'style', 'script'
+ * - filePath: original asset file path
+ *
+ * Note: images are not supported at the moment.
+ */
+export default function processAsset(content, assetType, filePath) {
+	//console.log("Processing ", filePath);
+	//
+	//if (assetType === 'style') {
+	//	// do style stuff, like post-css
+	//} else {
+	//	// do js stuff
+	//}
+	//
+	//console.log("Content: " + content.slice(0, 10));
+
+	return false; // returning false for skipping processing
+}

--- a/docs/en/2-organisation/1-content.md
+++ b/docs/en/2-organisation/1-content.md
@@ -163,7 +163,7 @@ There is no need for mental gymnastics when linking files. We have you covered.
 
 ## Images
 
-It's not uncommon for docs and pages to have images. To keep things simple, please put any image in the `docs/assets/images/` folder. At the moment, shromp will just copy these files to `public/assets/images/` as is.
+It's not uncommon for docs and pages to have images. Put any image in the `<docs>/assets/images/` folder. Shromp will hash and copy these files to `<public>/assets/images/`.
 
 I'm still debating if I should create any form of image optimisation pipeline, but this seems like a lot of complexity and maybe better handled beforehand with your own tooling.
 

--- a/docs/en/2-organisation/2-theme.md
+++ b/docs/en/2-organisation/2-theme.md
@@ -280,9 +280,10 @@ Here is an example:
 
 You can save your theme's assets in the `<theme>/assets` folder, either under `styles`, `scripts` or `images`.
 
-Assets are copied to their respective folders at `<public>/assets/`. At the moment, the only processing done is generating a content hash to append to the filenames to prevent wrong caching.
+Assets are copied to their respective folders at `<public>/assets/`. By default, Shromp will generate a content hash to append to the filenames to prevent wrong caching, and copy the content as-is.
+If you want to process styles and script assets further, you can define an [asset pipeline](../2-reference/5-asset-pipeline.md) that can change the file content before saving it.
 
-These assets will be available in the `assets` variable in the template's root context, so they can be inserted in the page correctly. Here is an example:
+The assets will be available in the `assets` variable in the template's root context, so they can be inserted in the page correctly. Here is an example:
 
 ```hbs
 <html">
@@ -323,6 +324,4 @@ The `assets` variable properties are maps of the original file name and the publ
 ```
 
 Sometimes you might want assets to be included in a given order (i.e a reset.css before the base.css). For that, you can either add them by name using the asset map, or use the same numbering pattern as the other content files: `0-reset.css`, `1-base.css`;
-
-_Note: At the moment, no further processing is done in the assets file, because it can get very complicated and opinionated. I'm still thinking about the best approach for this, but most likely it will be providing a way to modify the asset content before creation._
 

--- a/docs/en/2-reference/2-config-file.md
+++ b/docs/en/2-reference/2-config-file.md
@@ -13,6 +13,7 @@ Shromp's configuration file.
 |`source_folder`| Folder where the source markdown files are located<br/>Default: `./docs/` |
 |`output_folder`| Folder where the generated HTML files should be saved<br/>Default: `./public/` |
 |`theme_folder`| Folder where site theme handlebars templates are located<br/>Default: `./default-theme/` |
+|`asset_pipeline_file`| Path to asset processing file. Optional. Check [the reference](./5-asset-pipeline.md) for more details. |
 |`generate_doc_index`| Can disable doc index generation even when index.md is present<br/>Default: `false` |
 |`enable_versions`| Include version in the URL<br/>Default: `true` |
 |`version_to_publish`| Documentation version (files will be nested in this folder)<br/>Default: `1.0.0` |

--- a/docs/en/2-reference/5-asset-pipeline.md
+++ b/docs/en/2-reference/5-asset-pipeline.md
@@ -1,0 +1,45 @@
+<!--
+nav_max: 1
+-->
+# Asset Pipeline
+
+Asset pipelines can get very complicated and very opinionated. To keep things simple, the only processing Shromp does by default
+is appending the content hash to the file name, to prevent cache issues.
+
+To support more complex content processing, Shromp allows defining an asset pipeline file that can change the content of styles and scripts files before saving them.
+
+You can define the path for this asset pipeline file in `shromp.toml`. It should be a javascript file and export a method following the contract bellow:
+
+```javascript
+export default function processAsset(content, assetType, filePath) {
+	return "new content ";
+}
+```
+
+The method receives the following arguments:
+- `content`: The original content of the file
+- `assetType`: either `style` or `script`. Images are not supported at the moment.
+- `filePath`: path to the source file.
+
+Return:
+
+The method should return the new modified content. You can also return `false` to skip processing and use the original content.
+
+## Example
+
+Here is an example processing CSS files with postcss.
+
+```javascript
+import autoprefixer from 'autoprefixer'
+import postcss from 'postcss'
+
+
+export default async function processAsset(content, assetType, filePath) {
+  if (assetType === "style") {
+    return postcss([autoprefixer])
+      .process(content)
+      .then(result =>  result.css);
+  }
+  return false; // skip processing for files other than styles
+}
+```

--- a/shromp.toml
+++ b/shromp.toml
@@ -10,6 +10,9 @@ output_folder="./public/"
 # Folder where site theme handlebars templates are located
 theme_folder="./default-theme/"
 
+# Path to asset processing file. Optional.
+asset_pipeline_file="./asset-pipeline.js"
+
 # Default template used for pages
 default_page_template="page"
 

--- a/shromp.toml
+++ b/shromp.toml
@@ -13,9 +13,6 @@ theme_folder="./default-theme/"
 # Path to asset processing file. Optional.
 asset_pipeline_file="./asset-pipeline.js"
 
-# Default template used for pages
-default_page_template="page"
-
 # Can disable doc index generation even when index.md is present
 # default: false
 generate_doc_index=false

--- a/src/assets.test.ts
+++ b/src/assets.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, afterEach, beforeEach, mock, Mock } from 'node:test';
+import * as assert from 'node:assert';
+import mockFs from 'mock-fs';
+import config from './config.ts';
+import { fileExists } from './files.ts';
+import * as assetsModule from './assets.ts';
+
+
+describe('Assets', async () => {
+	const filesModule = await import('./files.ts');
+	// mock fs does not support cp :/
+	let cpToMock: Mock<typeof filesModule.copyTo>;
+	let createTargetAssetsWithHash: typeof assetsModule.createTargetAssetsWithHash;
+	let filesMock: Mock<any>;
+
+	cpToMock = mock.fn()
+	cpToMock.mock.mockImplementation(async function(_from, _to): Promise<void> {});
+
+	beforeEach(async () => {
+		cpToMock = mock.fn()
+		cpToMock.mock.mockImplementation(async function(_from, _to): Promise<void> {});
+
+		filesMock = mock.module('./files.ts', {
+			namedExports: {
+				...filesModule,
+				copyTo: async (from: string, to: string) => {
+					await cpToMock(from, to);
+				},
+			},
+		});
+
+		({ createTargetAssetsWithHash } = await import('./assets.ts'));
+	});
+
+	afterEach(() => {
+		mockFs.restore();
+		filesMock.restore();
+		cpToMock.mock.restore();
+	});
+
+	describe('#createTargetAssetsWithHash', () => {
+		it('creates theme styles target with hash', async () => {
+			mockFs({
+				[config.themeAssetsFolder('styles', 'test.css')]: 'content 1',
+				[config.themeAssetsFolder('styles', 'test2.css')]: 'content 2',
+				[config.themeAssetsFolder('styles', 'test3.css')]: 'content 3',
+			});
+
+			const result = await createTargetAssetsWithHash('styles');
+
+			assert.deepEqual(result, {
+				'test.css': '/assets/styles/test.bea1859e35.css',
+				'test2.css': '/assets/styles/test2.671a8c3fcc.css',
+				'test3.css': '/assets/styles/test3.bc6789bd60.css',
+			});
+
+			for (let f of Object.values(result)) {
+				assert.equal(fileExists(config.outputFolder(f)), true);
+			}
+		});
+
+		it('creates theme scripts target with hash', async () => {
+			mockFs({
+				[config.themeAssetsFolder('scripts', 'test.js')]: 'content 1',
+				[config.themeAssetsFolder('scripts', 'test2.js')]: 'content 2',
+			});
+
+			const result = await createTargetAssetsWithHash('scripts');
+
+			assert.deepEqual(result, {
+				'test.js': '/assets/scripts/test.bea1859e35.js',
+				'test2.js': '/assets/scripts/test2.671a8c3fcc.js',
+			});
+
+			for (let f of Object.values(result)) {
+				assert.equal(fileExists(config.outputFolder(f)), true);
+			}
+		});
+
+		it('creates theme images target with hash', async () => {
+			const imageContent1 = Buffer.from([8, 6, 7, 5, 3, 0, 9]);
+			const imageContent2 = Buffer.from([8, 6, 7, 6, 4, 1, 9]);
+
+			mockFs({
+				[config.themeAssetsFolder('images', 'test.png')]: imageContent1,
+				[config.themeAssetsFolder('images', 'test2.png')]: imageContent2,
+			});
+
+			const result = await createTargetAssetsWithHash('images');
+
+			assert.deepEqual(result, {
+				'test.png': '/assets/images/test.cc5d61b405.png',
+				'test2.png': '/assets/images/test2.ea000a0243.png',
+			});
+
+			assert.equal(cpToMock.mock.calls.length === 2, true);
+
+			let calls = 0;
+			for (let [fileName, outputPath] of Object.entries(result)) {
+				assert.deepEqual(cpToMock.mock.calls[calls].arguments, [
+					config.themeAssetsFolder('images', fileName),
+					config.outputFolder(outputPath)
+				]);
+				calls += 1;
+			}
+		});
+
+		it('creates content images target with hash', async () => {
+			const imageContent1 = Buffer.from([8, 6, 7, 5, 3, 0, 9]);
+			const imageContent2 = Buffer.from([8, 6, 7, 6, 4, 1, 9]);
+
+			mockFs({
+				[config.sourceFolder('images', 'test.png')]: imageContent1,
+				[config.sourceFolder('images', 'test2.png')]: imageContent2,
+			});
+
+			const result = await createTargetAssetsWithHash('content/images');
+
+			assert.deepEqual(result, {
+				'test.png': '/assets/content/images/test.cc5d61b405.png',
+				'test2.png': '/assets/content/images/test2.ea000a0243.png',
+			});
+
+			assert.equal(cpToMock.mock.calls.length === 2, true)
+
+			let calls = 0;
+			for (let [fileName, outputPath] of Object.entries(result)) {
+				assert.deepEqual(cpToMock.mock.calls[calls].arguments, [
+					config.sourceFolder('images', fileName),
+					config.outputFolder(outputPath)
+				]);
+				calls += 1;
+			}
+		});
+
+
+		it('returns empty when source folder not found', async () => {
+			mockFs({});
+
+			assert.deepEqual(await createTargetAssetsWithHash('styles'), {});
+			assert.deepEqual(await createTargetAssetsWithHash('scripts'), {});
+			assert.deepEqual(await createTargetAssetsWithHash('images'), {});
+			assert.deepEqual(await createTargetAssetsWithHash('content/images'), {});
+		});
+	});
+
+	describe('#compileSiteAssets', () => {
+		let compileSiteAssets: typeof assetsModule.compileSiteAssets;
+
+		beforeEach(async () => {
+			({ compileSiteAssets } = await import('./assets.ts'));
+		});
+
+		it('compile all assets in theme', async () => {
+			mockFs({
+				[config.themeAssetsFolder('styles', 'test.css')]: 'content 1',
+				[config.themeAssetsFolder('styles', 'test2.css')]: 'content 2',
+				[config.themeAssetsFolder('scripts', 'test.js')]: 'content 1',
+				[config.themeAssetsFolder('scripts', 'test2.js')]: 'content 2',
+				[config.themeAssetsFolder('images', 'test.png')]: Buffer.from([8, 6, 7, 5, 3, 0, 9]),
+				[config.themeAssetsFolder('images', 'test2.png')]: Buffer.from([8, 6, 7, 6, 4, 1, 9]),
+			});
+			const result = await compileSiteAssets();
+
+			assert.deepEqual(result, {
+				styles: {
+					'test.css': '/assets/styles/test.bea1859e35.css',
+					'test2.css': '/assets/styles/test2.671a8c3fcc.css',
+				},
+				scripts: {
+					'test.js': '/assets/scripts/test.bea1859e35.js',
+					'test2.js': '/assets/scripts/test2.671a8c3fcc.js',
+				},
+				images: {
+					'test.png': '/assets/images/test.cc5d61b405.png',
+					'test2.png': '/assets/images/test2.ea000a0243.png',
+				}
+			});
+		});
+
+		it('returns empty when folder does not exist', async () => {
+			mockFs({});
+			const result = await compileSiteAssets();
+
+			assert.deepEqual(result, {
+				styles: {},
+				scripts: {},
+				images: {},
+			});
+		});
+	});
+
+});

--- a/src/assets.test.ts
+++ b/src/assets.test.ts
@@ -110,8 +110,8 @@ describe('Assets', async () => {
 			const imageContent2 = Buffer.from([8, 6, 7, 6, 4, 1, 9]);
 
 			mockFs({
-				[config.sourceFolder('images', 'test.png')]: imageContent1,
-				[config.sourceFolder('images', 'test2.png')]: imageContent2,
+				[config.sourceFolder('assets', 'images', 'test.png')]: imageContent1,
+				[config.sourceFolder('assets', 'images', 'test2.png')]: imageContent2,
 			});
 
 			const result = await createTargetAssetsWithHash('content/images');
@@ -126,7 +126,7 @@ describe('Assets', async () => {
 			let calls = 0;
 			for (let [fileName, outputPath] of Object.entries(result)) {
 				assert.deepEqual(cpToMock.mock.calls[calls].arguments, [
-					config.sourceFolder('images', fileName),
+					config.sourceFolder('assets', 'images', fileName),
 					config.outputFolder(outputPath)
 				]);
 				calls += 1;

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -41,7 +41,7 @@ export async function compileSiteAssets(): Promise<SiteAssets> {
 }
 
 export async function createTargetAssetsWithHash(assetFolder: AssetFolder): Promise<AssetMap> {
-	const rootFolder = assetFolder === "content/images" ? config.sourceFolder("images") : config.themeAssetsFolder(assetFolder);
+	const rootFolder = assetFolder === "content/images" ? config.sourceFolder("assets", "images") : config.themeAssetsFolder(assetFolder);
 
 	if (!fileExists(rootFolder)) {
 		return {};

--- a/src/build-files.ts
+++ b/src/build-files.ts
@@ -6,7 +6,7 @@ import { ContentAnchor, ContentNode } from "./content-conversion.ts";
 import config, { loadSiteInfo, SiteInfo } from "./config.ts";
 import { copyTo, createFile, fileExists, listFilesInDir, listFilesInDirWithTypes } from "./files.ts";
 import Templates, { TemplatesInstance } from "./templates.ts";
-import { compileSiteAssets, SiteAssets } from "./assets.ts";
+import { AssetMap, compileSiteAssets, createTargetAssetsWithHash, SiteAssets } from "./assets.ts";
 import * as logs from "./logs.ts";
 
 interface ContentData {
@@ -256,12 +256,12 @@ async function createPage(filePath: string, content: any, templates: TemplatesIn
 	await createFile(config.outputFolder(filePath), pageContent);
 }
 
-export async function copyImages(): Promise<void> {
+export async function copyImages(): Promise<AssetMap> {
 	if (!fileExists(config.sourceFolder("assets", "images"))) {
-		return;
+		logs.info("Content images folder does not exist. Skipping copy.");
+		return {};
 	}
-
-	await copyTo(config.sourceFolder("assets", "images"), config.outputFolder("assets", "images"));
+	return createTargetAssetsWithHash("content/images");
 }
 
 async function updateVersionsFiles(navigationLinksByLocale: NavigationLinksForLocale | string ): Promise<void> {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,12 +14,12 @@ export async function build(configFile: string, tag: string, outputFolder: strin
 
 	logs.start("Reading source files");
 	const tree = await getFileTree(config.sourceFolder(), { excludeEmptyFolders: true });
+	logs.start("Copying content images");
+	const contentImages = await copyImages();
 	logs.start("Converting Markdown to HTML");
-	const contentTree = await generateHtmlForTree(tree);
+	const contentTree = await generateHtmlForTree(tree, contentImages);
 	logs.start("Creating target files");
 	await createSiteFromContent(contentTree);
-	logs.start("Copying images folder");
-	await copyImages();
 	
 	logs.logShrimplySuccess("Build complete");
 	logs.info(`Your new files are at ${config.outputFolder()}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ interface Config {
   enable_locales?: boolean;
   version_to_publish?: string;
   anchor_prefix?: string;
+  asset_pipeline_file?: string;
 }
 
 interface ThemeConfig {
@@ -142,6 +143,13 @@ export default {
   anchorPrefix(): string {
     return config.anchor_prefix || "sp-";
   },
+
+  assetPipelinePath(): string {
+    if (!config.asset_pipeline_file) {
+      return "";
+    }
+    return folderPathAssemblyHelper(config.asset_pipeline_file);
+  }
 }
 
 function folderPathAssemblyHelper(folder: string, args: string[] = []) {


### PR DESCRIPTION

- Implemented asset pipeline file to allow users to modify styles and scripts before saving
- Hashing content images
- Fixed content images not using baseUrl when traslating paths