### PR TITLE
docs: added page navigation and some fixes

### DIFF
--- a/default-theme/assets/styles/1-main.css
+++ b/default-theme/assets/styles/1-main.css
@@ -60,6 +60,7 @@ h4 { font-size: 1em; }
 .content {
 	padding: 24px;
 	margin-top: 48px;
+	width: 100%;
 } 
 
 .content.with-menu {
@@ -434,4 +435,24 @@ h4 { font-size: 1em; }
 .footer-credits a {
 	text-decoration: none;
 	font-size: 0.9em;
+}
+
+.page-navigation {
+	width: 100%;
+	display: flex;
+
+	.previous {
+		flex-grow: 1;
+		text-align: left;
+		text-decoration: none;
+	}
+	.next {
+		flex-grow: 1;
+		text-align: right;
+		text-decoration: none;
+	}
+}
+
+.table-examples table th:nth-child(1) {
+	width: auto;
 }

--- a/default-theme/templates/helpers.js
+++ b/default-theme/templates/helpers.js
@@ -9,8 +9,10 @@
 *
 */
 
-// Helper to return the initial state for the navigation menu, such as
-// which menu item should be expanded or not when loading the page
+/**
+ * Helper to return the initial state for the navigation menu, such as
+ * which menu item should be expanded or not when loading the page
+*/
 export function getNavCurrentState(navLink, currentFile) {
 	// skip anchors as they can't be expanded
 	if (navLink.includes("#")) {
@@ -31,25 +33,41 @@ export function getNavCurrentState(navLink, currentFile) {
 	return "collapsed";
 }
 
-// Helper to return the "current" class when the navigation link refers to the
-// current file
+/**
+ * Helper to return the "current" class when the navigation link refers to the
+ * current file
+*/
 export function getNavClassWhenCurrent(navLink, currentFile) {
 	return navLink === currentFile ? "current" : "";
 };
 
+/**
+ * Joins args into a path
+*/
 export function buildLink(...args) {
 	const parts = args.filter((a) => typeof a === "string");
 	return parts.join("/").replaceAll(/\/+/g, "/");
 }
 
+/**
+ * Returns the full path for image.
+ */
 export function assetImage(imageName) {
 	return this.assets.images[imageName];
 }
 
+/**
+ * Returns page description from the page metadata, or fallback
+ * to the site description
+ */
 export function pageDescriptionWithFallback() {
 	return this.metadata.description || this.site.description
 }
 
+/**
+ * Returns page image from the page metadata, or fallback
+ * to the site image
+ */
 export function pageImageWithFallback() {
 	const image = this.metadata.page_image || this.site.image;
 
@@ -60,13 +78,102 @@ export function pageImageWithFallback() {
 	return image;
 }
 
+/**
+ * Returns keywords set on the page metadata, or fallback
+ * to the site keywords
+ */
 export function pageKeywordsWithFallback() {
 	return this.metadata.keywords || this.site.keywords
 }
 
+/**
+ * Returns "page title - site title".
+ * In cases where no page title is set, returns only the site title.
+ */
 export function fullPageTitle() {
 	if (this.pageTitle) {
 		return `${this.pageTitle} - ${this.site.title}`;
 	}
 	return this.site.title;
+}
+
+/**
+ * Returns previous and next link HTML elements to be used
+ * in the page bottom navigation.
+ * It uses the navigationMenu links to find what is the previous and
+ * pages for the page provided
+ */
+export function getPageNavigationLinks(currentPage) {
+	const listStack = [
+		{ list: [this.navigationMenu], index: 0 },
+	]
+
+	let previousItem;
+	let nextItem;
+	let wasFound = false;
+
+	while (listStack.length > 0) {
+		const currentStack = listStack.length - 1;
+		const stack = listStack[currentStack];
+
+		while (stack.index < stack.list.length) {
+			const item = stack.list[stack.index];
+			stack.index += 1;
+
+			// skip anchors
+			if (item.level > 1) {
+				continue;
+			}
+
+			if (wasFound) {
+				nextItem = item;
+				break;
+			}
+
+			if (item.path === currentPage) {
+				wasFound = true;
+				if (item.children && item.children.length) {
+					for (let child of item.children) {
+						if (child.level === 1) {
+							nextItem = child;
+							break;
+						}
+					}
+					if (nextItem) {
+						break;
+					}
+				}
+			} else {
+				previousItem = item;
+				if (item.children && item.children.length) {
+					listStack.push({ list: item.children, index: 0 });
+					break;
+				}
+			}
+		}
+
+		if (wasFound && nextItem) {
+			break;
+		}
+
+		if (stack.index >= stack.list.length && currentStack == listStack.length - 1) {
+			listStack.pop();
+		}
+	}
+
+	if (!wasFound) {
+		return "";
+	}
+
+	let links = "";
+
+	if (previousItem) {
+		links += `<a href="${previousItem.path}" class="previous">Previous: ${previousItem.title}</a>`;
+	}
+
+	if (nextItem) {
+		links += `<a href="${nextItem.path}" class="next">Next: ${nextItem.title}</a>`;
+	}
+
+	return links;
 }

--- a/default-theme/templates/page-with-child-list.hbs
+++ b/default-theme/templates/page-with-child-list.hbs
@@ -3,5 +3,6 @@
 <main class="content page-doc with-menu" role="main">
 	{{{ mainContent }}}
 	{{> child-list }}
+	{{> page-navigation }}
 </main>
 {{> footer }}

--- a/default-theme/templates/page.hbs
+++ b/default-theme/templates/page.hbs
@@ -1,6 +1,7 @@
 {{> header }}
 {{> side-navigation }}
-<main class="content page-doc with-menu" role="main">
+<main class="content page-doc with-menu {{metadata.page_custom_class}}" role="main">
 	{{{ mainContent }}}
+	{{> page-navigation }}
 </main>
 {{> footer }}

--- a/default-theme/templates/partials/page-navigation.hbs
+++ b/default-theme/templates/partials/page-navigation.hbs
@@ -1,0 +1,8 @@
+<nav>
+  <hr/>
+
+  <div class="page-navigation">
+    {{{ getPageNavigationLinks @root.currentFilePath}}}
+  </div>
+</nav>
+

--- a/docs/en/2-organisation/1-content.md
+++ b/docs/en/2-organisation/1-content.md
@@ -1,3 +1,6 @@
+<!--
+page_custom_class: table-examples
+-->
 # Content files (a.k.a. /docs)
 
 The `<docs>/` folder holds your source files. Those files should be written in `markdown`, and the file structure is then mirrored in the `<public>/` folder. For example, the file `docs/en/1.0.0/introduction/index.md` will be available as `public/en/1.0.0/introduction/index.html`.
@@ -261,12 +264,11 @@ and ability to define column's width:
 ```markdown
 
 |Column One|Column Two|Column Three|
-|--10%-----|-- 40% ---|:---50%-----|
+|--10%-----|-- 40% ---|----50%-----|
+| Cell A   | Cell B   | Cell C     |
 
 ```
 
 |Column One|Column Two|Column Three|
-|--10%-----|-- 40% ---|:---50%-----|
-
-
-
+|--10%-----|-- 40% ---|----50%-----|
+| Cell A   | Cell B   | Cell C     |

--- a/docs/en/2-organisation/2-theme.md
+++ b/docs/en/2-organisation/2-theme.md
@@ -4,10 +4,9 @@ While the `/docs` folder holds the content for the site, the `/theme` folder hol
 
 ## Configuring a theme
 
-You can set your current theme configuration in the `shromp.toml` file, using the following properties:
+You can set your current theme configuration in the `shromp.toml` file using the following property:
 
 - `theme_folder="./default-theme/"` -- folder where the theme is located
-- `default_page_template="page"` -- default template to use
 
 ## Folder structure
 

--- a/shromp.toml
+++ b/shromp.toml
@@ -22,7 +22,8 @@ generate_doc_index=false
 enable_versions=true
 
 # Documentation version (files will be nested in this folder)
-version_to_publish="0.0.1"
+# e.g. "0.0.1", "stable", "main"
+version_to_publish="main"
 
 # When enabled the first folder level are the locales roots
 # and each locale root has independent navigation

--- a/src/build-files.ts
+++ b/src/build-files.ts
@@ -4,7 +4,7 @@
 import path from "node:path";
 import { ContentAnchor, ContentNode } from "./content-conversion.ts";
 import config, { loadSiteInfo, SiteInfo } from "./config.ts";
-import { copyTo, createFile, fileExists, listFilesInDir, listFilesInDirWithTypes } from "./files.ts";
+import { createFile, fileExists, listFilesInDirWithTypes } from "./files.ts";
 import Templates, { TemplatesInstance } from "./templates.ts";
 import { AssetMap, compileSiteAssets, createTargetAssetsWithHash, SiteAssets } from "./assets.ts";
 import * as logs from "./logs.ts";


### PR DESCRIPTION
Fixed docs and also added example to how to show previous and next page in the template. Like this:

<img width="1275" height="549" alt="Screenshot from 2025-08-06 17-12-30" src="https://github.com/user-attachments/assets/3b5a38c8-e70b-4c3a-aa72-27f956983cd6" />
